### PR TITLE
Fix added

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -803,6 +803,9 @@ public class ChannelSftp extends ChannelSession{
           try{
             int _len=len;
             while(_len>0){
+	          if(rwsize<21+handle.length+_len+4) {
+	        	flush();
+	          }
               int sent=sendWRITE(handle, _offset[0], d, s, _len);
               writecount++;
               _offset[0]+=sent;


### PR DESCRIPTION
Fix for #38 

File output stream is flushed just before remote window size is diminished. This will avoid choking channel piped input stream buffer and session thread will be able to ingest SSH_MSG_CHANNEL_WINDOW_ADJUST.